### PR TITLE
Updating polystat/odin to v0.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@ SOFTWARE.
     </site>
   </distributionManagement>
   <properties>
-    <odin.version>0.3.0</odin.version>
+    <odin.version>0.3.2</odin.version>
     <eo.version>0.21.8</eo.version>
   </properties>
   <dependencies>
@@ -127,11 +127,6 @@ SOFTWARE.
     <dependency>
       <groupId>org.polystat.odin</groupId>
       <artifactId>interop_2.13</artifactId>
-      <version>${odin.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.polystat.odin</groupId>
-      <artifactId>analysis_2.13</artifactId>
       <version>${odin.version}</version>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@ SOFTWARE.
     </site>
   </distributionManagement>
   <properties>
-    <odin.version>0.2.1</odin.version>
+    <odin.version>0.3.0</odin.version>
     <eo.version>0.21.8</eo.version>
   </properties>
   <dependencies>

--- a/src/main/java/org/polystat/AnOdin.java
+++ b/src/main/java/org/polystat/AnOdin.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.cactoos.Func;
 import org.cactoos.list.ListOf;
-import org.polystat.odin.analysis.mutualrec.naive.exceptions.UnsupportedDecoration;
 import org.polystat.odin.interop.java.EOOdinAnalyzer;
 import org.polystat.odin.interop.java.OdinAnalysisErrorInterop;
 
@@ -41,6 +40,7 @@ import org.polystat.odin.interop.java.OdinAnalysisErrorInterop;
 public final class AnOdin implements Analysis {
 
     @Override
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     public Iterable<String> errors(final Func<String, XML> xmir,
         final String locator) throws Exception {
         final XML xml = xmir.apply(locator);
@@ -51,7 +51,8 @@ public final class AnOdin implements Analysis {
                 .analyze(str).stream()
                 .map(OdinAnalysisErrorInterop::message)
                 .collect(Collectors.toList());
-        } catch (final UnsupportedDecoration ex) {
+        // @checkstyle IllegalCatchCheck (1 line)
+        } catch (final Exception ex) {
             result = new ListOf<>(
                 String.format("Odin is not able to analyze the code, due to:%n%s", ex.getMessage())
             );


### PR DESCRIPTION
- 3rd defect should now be detected. Example code:
```
[] > test
  [] > parent
    [self x] > f
      x.sub 5 > y1
      seq > @
        assert (0.less y1)
        x
    [self y] > g
      self.f self y > @
    [self z] > h
      z > @
  [] > child
    parent > @
    [self y] > f
      y > @
    [self z] > h
      self.g self z > @
```
Should yield:
```
[Unjustified Assumption] Method g is not referentially transparent
```
This means that the re-definition of method "f" in "child" adversely affected the properties of method "g", which was inherited from "parent".
(error messages will be improved in future versions)
- The restriction for fully-qualified name in `@`-attribute declaration is lifted. The following code is allowed now (in reference to #43):
```
[] > test
  [] > main
    0 > @
  [] > test1
    main > @
```
