### PR TITLE
Analysis changes

### DIFF
--- a/src/main/java/org/polystat/AnFaR.java
+++ b/src/main/java/org/polystat/AnFaR.java
@@ -23,9 +23,9 @@
  */
 package org.polystat;
 
-import org.cactoos.list.ListOf;
 import com.jcabi.xml.XML;
 import org.cactoos.Func;
+import org.cactoos.list.ListOf;
 import org.polystat.far.FaR;
 
 /**
@@ -37,14 +37,18 @@ import org.polystat.far.FaR;
 public final class AnFaR implements Analysis {
 
     @Override
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     public Iterable<Result> errors(final Func<String, XML> xmir,
         final String locator) {
+        Result result;
         try {
-            Iterable<String> errors = new FaR().errors(xmir, locator);
-            return new ListOf<>(new Result.Completed(AnFaR.class, errors));
-        } catch (final Exception e) {
-            return new ListOf<>(new Result.Failed(AnFaR.class, e));
+            final Iterable<String> errors = new FaR().errors(xmir, locator);
+            result = new Result.Completed(AnFaR.class, errors);
+        // @checkstyle IllegalCatchCheck (1 line)
+        } catch (final Exception ex) {
+            result = new Result.Failed(AnFaR.class, ex);
         }
+        return new ListOf<Result>(result);
     }
 
 }

--- a/src/main/java/org/polystat/AnFaR.java
+++ b/src/main/java/org/polystat/AnFaR.java
@@ -23,6 +23,7 @@
  */
 package org.polystat;
 
+import org.cactoos.list.ListOf;
 import com.jcabi.xml.XML;
 import org.cactoos.Func;
 import org.polystat.far.FaR;
@@ -36,9 +37,14 @@ import org.polystat.far.FaR;
 public final class AnFaR implements Analysis {
 
     @Override
-    public Iterable<String> errors(final Func<String, XML> xmir,
-        final String locator) throws Exception {
-        return new FaR().errors(xmir, locator);
+    public Iterable<Result> errors(final Func<String, XML> xmir,
+        final String locator) {
+        try {
+            Iterable<String> errors = new FaR().errors(xmir, locator);
+            return new ListOf<>(new Result.Completed(AnFaR.class, errors));
+        } catch (final Exception e) {
+            return new ListOf<>(new Result.Failed(AnFaR.class, e));
+        }
     }
 
 }

--- a/src/main/java/org/polystat/AnOdin.java
+++ b/src/main/java/org/polystat/AnOdin.java
@@ -41,7 +41,7 @@ public final class AnOdin implements Analysis {
 
     @Override
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
-    public Iterable<String> errors(final Func<String, XML> xmir,
+    public Iterable<Result> errors(final Func<String, XML> xmir,
         final String locator) throws Exception {
         final XML xml = xmir.apply(locator);
         final String str = getObjectsHierarchy(xmir, xml);
@@ -51,13 +51,11 @@ public final class AnOdin implements Analysis {
                 .analyze(str).stream()
                 .map(OdinAnalysisErrorInterop::message)
                 .collect(Collectors.toList());
+            return new ListOf<>(new Result.Completed(AnOdin.class, result));
         // @checkstyle IllegalCatchCheck (1 line)
         } catch (final Exception ex) {
-            result = new ListOf<>(
-                String.format("Odin is not able to analyze the code, due to:%n%s", ex.getMessage())
-            );
+            return new ListOf<>(new Result.Failed(AnOdin.class, ex));
         }
-        return result;
     }
 
     /**

--- a/src/main/java/org/polystat/AnOdin.java
+++ b/src/main/java/org/polystat/AnOdin.java
@@ -45,17 +45,18 @@ public final class AnOdin implements Analysis {
         final String locator) throws Exception {
         final XML xml = xmir.apply(locator);
         final String str = getObjectsHierarchy(xmir, xml);
-        Iterable<String> result;
+        Result result;
         try {
-            result = new EOOdinAnalyzer.EOOdinXmirAnalyzer()
+            final Iterable<String> errors = new EOOdinAnalyzer.EOOdinXmirAnalyzer()
                 .analyze(str).stream()
                 .map(OdinAnalysisErrorInterop::message)
                 .collect(Collectors.toList());
-            return new ListOf<>(new Result.Completed(AnOdin.class, result));
+            result = new Result.Completed(AnOdin.class, errors);
         // @checkstyle IllegalCatchCheck (1 line)
         } catch (final Exception ex) {
-            return new ListOf<>(new Result.Failed(AnOdin.class, ex));
+            result = new Result.Failed(AnOdin.class, ex);
         }
+        return new ListOf<Result>(result);
     }
 
     /**

--- a/src/main/java/org/polystat/Analysis.java
+++ b/src/main/java/org/polystat/Analysis.java
@@ -42,7 +42,7 @@ public interface Analysis {
      * @return List of exceptions
      * @throws Exception If fails
      */
-    Iterable<String> errors(Func<String, XML> xmir,
+    Iterable<Result> errors(Func<String, XML> xmir,
         String locator) throws Exception;
 
 }

--- a/src/main/java/org/polystat/Polystat.java
+++ b/src/main/java/org/polystat/Polystat.java
@@ -29,7 +29,6 @@ import com.jcabi.xml.XML;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
 import org.cactoos.Func;
@@ -134,8 +133,7 @@ public final class Polystat implements Callable<Integer> {
         final Collection<Result> errors = new ArrayList<>(Polystat.ALL.length);
         for (final Analysis analysis : Polystat.ALL) {
             try {
-                final List<String> found = new ListOf<>(analysis.errors(xmir, "\\Phi.test"));
-                errors.add(new Result.Completed(analysis.getClass(), found));
+                errors.addAll(new ListOf<>(analysis.errors(xmir, "\\Phi.test")));
             // @checkstyle IllegalCatchCheck (1 line)
             } catch (final Exception ex) {
                 errors.add(new Result.Failed(analysis.getClass(), ex));


### PR DESCRIPTION
The signature of `Analysis.errors` was changed to return `Iterable<org.polystat.Result>` instead of `Iterable<String>`. This was done to:
- Give implementers of `Analysis` more freedom in how to define `Completed` and `Failed`.
- To make it more extensible, e.g. via implementing `Result` or adding fields to existing instances, like `Completed`.

This PR is a part of a series of PRs towards a better SARIF support described in #49.