### PR TITLE
Temporary files go into a temporary directory by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,7 @@ SOFTWARE.
                 <argument>-jar</argument>
                 <argument>${project.build.finalName}-jar-with-dependencies.jar</argument>
                 <argument>${project.basedir}/src/test/resources/org/polystat</argument>
+                <argument>--tmp</argument>
                 <argument>${project.build.directory}/polystat-temp</argument>
               </arguments>
             </configuration>

--- a/src/main/java/org/polystat/Polystat.java
+++ b/src/main/java/org/polystat/Polystat.java
@@ -26,7 +26,6 @@ package org.polystat;
 import com.jcabi.log.Logger;
 import com.jcabi.manifests.Manifests;
 import com.jcabi.xml.XML;
-
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -85,8 +84,8 @@ public final class Polystat implements Callable<Integer> {
      */
     @CommandLine.Option(
         names = "--tmp",
-        description = "The directory with .XML files and maybe other temp." +
-         "If not specified, defaults to a temporary directory."
+        // @checkstyle LineLengthCheck (1 line)
+        description = "The directory with .XML files and maybe other temp. If not specified, defaults to a temporary directory."
     )
     private Path temp;
 
@@ -113,9 +112,14 @@ public final class Polystat implements Callable<Integer> {
 
     @Override
     public Integer call() throws Exception {
-        final Path tmpDir = this.temp == null ? Files.createTempDirectory("polystat_tmp") : this.temp;
+        final Path tempdir;
+        if (this.temp == null) {
+            tempdir = Files.createTempDirectory("polystat-temp");
+        } else {
+            tempdir = this.temp;
+        }
         final Iterable<Result> errors =
-            Polystat.scan(this.source, tmpDir);
+            Polystat.scan(this.source, tempdir);
         final Supplier<String> out;
         if (this.sarif) {
             out = new AsSarif(errors);

--- a/src/main/java/org/polystat/Polystat.java
+++ b/src/main/java/org/polystat/Polystat.java
@@ -26,6 +26,8 @@ package org.polystat;
 import com.jcabi.log.Logger;
 import com.jcabi.manifests.Manifests;
 import com.jcabi.xml.XML;
+
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -81,9 +83,10 @@ public final class Polystat implements Callable<Integer> {
     /**
      * Output directoty.
      */
-    @CommandLine.Parameters(
-        index = "1",
-        description = "The directory with .XML files and maybe other temp."
+    @CommandLine.Option(
+        names = "--tmp",
+        description = "The directory with .XML files and maybe other temp." +
+         "If not specified, defaults to a temporary directory."
     )
     private Path temp;
 
@@ -110,8 +113,9 @@ public final class Polystat implements Callable<Integer> {
 
     @Override
     public Integer call() throws Exception {
+        final Path tmpDir = this.temp == null ? Files.createTempDirectory("polystat_tmp") : this.temp;
         final Iterable<Result> errors =
-            Polystat.scan(this.source, this.temp);
+            Polystat.scan(this.source, tmpDir);
         final Supplier<String> out;
         if (this.sarif) {
             out = new AsSarif(errors);


### PR DESCRIPTION
This PR addresses #41:
* Second parameter `tmp` is no longer required. All the temporary files go into a newly created temporary directory in the file system with the prefix `polystat-temp`. This should gurarantee, that every execution of Polystat generates new files, without the need to delete them manually. So, the following command is now valid:
  ```
  java -jar target/polystat-*-jar-with-dependencies.jar eo_files 
  ```
* If you want to specify where Polystat should output its temporary files, you can specify the directory with the `--tmp` option instead:
  ```
  java -jar target/polystat-*-jar-with-dependencies.jar eo_files --tmp target/polystat-temp
  ```