### PR TITLE
Polystat can read EO code from stdin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,6 +217,7 @@ SOFTWARE.
               <arguments>
                 <argument>-jar</argument>
                 <argument>${project.build.finalName}-jar-with-dependencies.jar</argument>
+                <argument>--files</argument>
                 <argument>${project.basedir}/src/test/resources/org/polystat</argument>
                 <argument>--tmp</argument>
                 <argument>${project.build.directory}/polystat-temp</argument>

--- a/src/main/java/org/polystat/Polystat.java
+++ b/src/main/java/org/polystat/Polystat.java
@@ -75,7 +75,7 @@ public final class Polystat implements Callable<Integer> {
     };
 
     /**
-     * Source directory. If not specified, defaults to reading code from standard output.
+     * Source directory. If not specified, defaults to reading code from standard input.
      */
     @CommandLine.Option(
         names = "--files",
@@ -169,7 +169,7 @@ public final class Polystat implements Callable<Integer> {
      * Reads the EO code from standard input,
      * creates a temporary directory and
      * writes the code to a new file in this directory called "test.eo".
-     * @return Path object of the temporary directory with test.eo file.
+     * @return Path object of "{tmpdir}/test.eo" files.
      * @throws Exception When IO fails.
      */
     private static Path readCodeFromStdin() throws Exception {

--- a/try.sh
+++ b/try.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-java -jar target/polystat-*-jar-with-dependencies.jar sandbox
+java -jar target/polystat-*-jar-with-dependencies.jar


### PR DESCRIPTION
### Changes
- `polystat.jar` no longer requires an "src" argument (a path to a directory with `.eo` files). If you want to analyze a directory with `.eo` files, you can do so via `--files` option:
  ```sh
  java -jar target/polystat-*-jar-with-dependencies.jar --files sandbox
  ```
- When the `--files` option is not supplied, `polystat.jar` reads the code from standard input. Due to limited capabilities of Polystat, it can only read one EO object called "test" . It is now possible to use `polystat.jar` in piping commands, for example:
  ```sh
  cat sandbox/test.eo | java -jar target/polystat-*-jar-with-dependencies.jar
  ```