### PR TITLE
Polystat can read command-line options from a `.polystat` file + new options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target/
 .idea/
 *.iml
 .DS_Store
+.vscode/

--- a/src/main/java/org/polystat/AnFaR.java
+++ b/src/main/java/org/polystat/AnFaR.java
@@ -39,7 +39,7 @@ public final class AnFaR implements Analysis {
     /**
      * A rule id for AnFaR analysis.
      */
-    private static final String RULE_ID = "Division by zero";
+    private static final String RULE_ID = "DIV0";
 
     @Override
     @SuppressWarnings("PMD.AvoidCatchingGenericException")

--- a/src/main/java/org/polystat/Config.java
+++ b/src/main/java/org/polystat/Config.java
@@ -91,6 +91,8 @@ public final class Config implements Iterable<Entry<String, String>> {
                 line -> {
                     final String[] parts = line.trim().split(" ", 2);
                     if (parts.length == 2) {
+                        
+                    Logger.warn(Config.class, String.join(" ", parts));
                         result.put(parts[0], parts[1]);
                     } else if (parts.length == 1 && parts[0].length() != 0) {
                         result.put(parts[0], "true");

--- a/src/main/java/org/polystat/Config.java
+++ b/src/main/java/org/polystat/Config.java
@@ -28,7 +28,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
@@ -36,7 +38,7 @@ import javax.annotation.Nullable;
  * Stores configuration for Polystat.
  * @since 1.0
  */
-public class Config {
+public final class Config implements Iterable<Entry<String, String>> {
 
     /**
      * Mapping between config options and their values.
@@ -57,6 +59,11 @@ public class Config {
      */
     public Config(final Path path) {
         this(parseConfig(path));
+    }
+
+    @Override
+    public Iterator<Entry<String, String>> iterator() {
+        return this.values.entrySet().iterator();
     }
 
     /**
@@ -84,7 +91,7 @@ public class Config {
                     final String[] parts = line.trim().split(" ", 2);
                     if (parts.length == 2) {
                         result.put(parts[0], parts[1]);
-                    } else if (parts.length == 1) {
+                    } else if (parts.length == 1 && parts[0].length() != 0) {
                         result.put(parts[0], "true");
                     }
                 }

--- a/src/main/java/org/polystat/Config.java
+++ b/src/main/java/org/polystat/Config.java
@@ -81,7 +81,8 @@ public final class Config implements Iterable<Entry<String, String>> {
      * @param path Path to ".polystat" file.
      * @return A map with successfully parsed options. If an error occurs, return an empty Map.
      * @todo #56:1h The current implementation is very prone to errors and
-     *  should be replaced with a more robust solution.
+     *  should be replaced with a more robust solution. I couldn't find a library
+     *  that does this kind of parsing better.
      */
     private static Map<String, String> parseConfig(final Path path) {
         final Map<String, String> result = new HashMap<>();

--- a/src/main/java/org/polystat/Config.java
+++ b/src/main/java/org/polystat/Config.java
@@ -29,9 +29,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.List;
 import org.cactoos.list.ListOf;
 
 /**
@@ -73,13 +73,13 @@ public final class Config implements Iterable<String> {
      */
     private static List<String> parseConfig(final Path path) {
         List<String> result;
-        try(Stream<String> st = Files.lines(path, StandardCharsets.UTF_8)) {
+        try (Stream<String> st = Files.lines(path, StandardCharsets.UTF_8)) {
             result = st.flatMap(line -> new ListOf<String>(line.trim().split("\\s+")).stream())
             .filter(s -> !s.isEmpty())
             .collect(Collectors.toList());
-        } catch (IOException e) {
+        } catch (final IOException ex) {
             result = new LinkedList<>();
         }
-        return result;    
+        return result;
     }
 }

--- a/src/main/java/org/polystat/Config.java
+++ b/src/main/java/org/polystat/Config.java
@@ -1,0 +1,103 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020-2022 Polystat.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.polystat;
+
+import com.jcabi.log.Logger;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+import javax.annotation.Nullable;
+
+/**
+ * Stores configuration for Polystat.
+ * @since 1.0
+ */
+public class Config {
+
+    /**
+     * Mapping between config options and their values.
+     */
+    private final Map<String, String> values;
+
+    /**
+     * Ctor.
+     * @param config Map with the config options and their values.
+     */
+    public Config(final Map<String, String> config) {
+        this.values = config;
+    }
+
+    /**
+     * Ctor.
+     * @param path Path to the file to read configs from.
+     */
+    public Config(final Path path) {
+        this(parseConfig(path));
+    }
+
+    /**
+     * Returns the value of the config option if present.
+     * @param key Config option.
+     * @return The value of the config option or {@code null}.
+     */
+    @Nullable
+    public String get(final String key) {
+        return this.values.get(key);
+    }
+
+    /**
+     * Reads command-line arguments from the ".polystat" file.
+     * @param path Path to ".polystat" file.
+     * @return A map with successfully parsed options. If an error occurs, return an empty Map.
+     * @todo #56:1h The current implementation is very prone to errors and
+     *  should be replaced with a more robust solution.
+     */
+    private static Map<String, String> parseConfig(final Path path) {
+        final Map<String, String> result = new HashMap<>();
+        try (Stream<String> st = Files.lines(path)) {
+            st.forEachOrdered(
+                line -> {
+                    final String[] parts = line.trim().split(" ", 2);
+                    if (parts.length == 2) {
+                        result.put(parts[0], parts[1]);
+                    } else if (parts.length == 1) {
+                        result.put(parts[0], "true");
+                    }
+                }
+            );
+        } catch (final IOException ex) {
+            Logger.warn(
+                Polystat.class,
+                String.format(
+                    "Could not read config file %s. Using options from command line...",
+                    path.toString()
+                )
+            );
+        }
+        return result;
+    }
+}

--- a/src/main/java/org/polystat/Polystat.java
+++ b/src/main/java/org/polystat/Polystat.java
@@ -31,6 +31,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
@@ -41,6 +42,7 @@ import org.cactoos.io.TeeInput;
 import org.cactoos.list.ListOf;
 import org.cactoos.scalar.LengthOf;
 import picocli.CommandLine;
+import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Model.ArgSpec;
 import picocli.CommandLine.Model.OptionSpec;
 
@@ -77,6 +79,18 @@ public final class Polystat implements Callable<Integer> {
         new AnFaR(),
         new AnOdin(),
     };
+
+
+    @ArgGroup(exclusive = true)
+    IncludeExclude ie;
+
+    static class IncludeExclude {
+        @CommandLine.Option(names = "--exclude", split=",", required = true) 
+        Collection<String> exclude;
+
+        @CommandLine.Option(names = "--include", split=",", required = true) 
+        Collection<String> include;
+    }
 
     /**
      * Source directory. If not specified, defaults to reading code from standard input.
@@ -138,6 +152,11 @@ public final class Polystat implements Callable<Integer> {
         } else {
             out = new AsConsole(errors);
         }
+
+        System.out.println(ie);
+        System.out.println(ie.include);
+        System.out.println(ie.exclude);
+
         Logger.info(this, "%s\n", out.get());
         return 0;
     }

--- a/src/main/java/org/polystat/Polystat.java
+++ b/src/main/java/org/polystat/Polystat.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import org.cactoos.Func;
 import org.cactoos.io.OutputTo;
 import org.cactoos.io.Stdin;
@@ -40,6 +41,8 @@ import org.cactoos.io.TeeInput;
 import org.cactoos.list.ListOf;
 import org.cactoos.scalar.LengthOf;
 import picocli.CommandLine;
+import picocli.CommandLine.Model.ArgSpec;
+import picocli.CommandLine.Model.OptionSpec;
 
 /**
  * Main entrance.
@@ -62,7 +65,8 @@ import picocli.CommandLine;
     helpCommand = true,
     description = "Read our README in GitHub",
     mixinStandardHelpOptions = true,
-    versionProvider = Polystat.Version.class
+    versionProvider = Polystat.Version.class,
+    defaultValueProvider = Polystat.ConfigProvider.class
 )
 public final class Polystat implements Callable<Integer> {
 
@@ -197,6 +201,33 @@ public final class Polystat implements Callable<Integer> {
                 Manifests.read("Polystat-Version"),
                 Manifests.read("EO-Version"),
             };
+        }
+    }
+
+    /**
+     * Used to provide values for cmdline options via a config file '.polystat'.
+     * @since 1.0
+     */
+    static final class ConfigProvider implements CommandLine.IDefaultValueProvider {
+
+        /**
+         * Configuration for Polystat.
+         */
+        private final Config config = new Config(Paths.get(".polystat"));
+
+        @Override
+        @Nullable
+        public String defaultValue(final ArgSpec arg) throws Exception {
+            final String result;
+            if (arg.isOption()) {
+                final OptionSpec opt = (OptionSpec) arg;
+                final String key = opt.longestName();
+                final String value = this.config.get(key);
+                result = value;
+            } else {
+                result = null;
+            }
+            return result;
         }
     }
 }

--- a/src/main/java/org/polystat/Polystat.java
+++ b/src/main/java/org/polystat/Polystat.java
@@ -31,6 +31,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -115,20 +116,12 @@ public final class Polystat implements Callable<Integer> {
      */
     @SuppressWarnings({"PMD.DoNotCallSystemExit", "PMD.AvoidCatchingGenericException"})
     public static void main(final String... cmdargs) {
-        final String[] confargs = new ListOf<String>(
+        final List<String> confargs = new ListOf<>(
             new Config(Paths.get(".polystat"))
-        ).toArray(new String[0]);
-        final Polystat config = new Polystat();
-        final Polystat cmdline = new Polystat();
-        new CommandLine(config).parseArgs(confargs);
-        new CommandLine(cmdline).parseArgs(cmdargs);
-        config.overrideBy(cmdline);
-        try {
-            System.exit(config.call());
-        // @checkstyle IllegalCatchCheck (1 line)
-        } catch (final Exception ex) {
-            Logger.warn(Polystat.class, ex.getMessage());
-        }
+        );
+        confargs.addAll(new ListOf<>(cmdargs));
+        final String[] args = confargs.toArray(new String[0]);
+        new CommandLine(new Polystat()).execute(args);
     }
 
     @Override
@@ -155,23 +148,6 @@ public final class Polystat implements Callable<Integer> {
         }
         Logger.info(this, "%s\n", out.get());
         return 0;
-    }
-
-    /**
-     * Overrides the options of {@code this} with theinitialized options of other.
-     * @param other Configs which will override this.
-     */
-    void overrideBy(final Polystat other) {
-        this.sarif = other.sarif;
-        if (other.temp != null) {
-            this.temp = other.temp;
-        }
-        if (other.source != null) {
-            this.source = other.source;
-        }
-        if (other.inex != null) {
-            this.inex = other.inex;
-        }
     }
 
     /**

--- a/src/test/java/org/polystat/ConfigTest.java
+++ b/src/test/java/org/polystat/ConfigTest.java
@@ -30,6 +30,7 @@ import java.nio.file.Path;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -49,10 +50,7 @@ final class ConfigTest {
         final Path file = tmp.resolve(ConfigTest.CONFIG_FILENAME);
         Files.write(file, "--files sandbox\n--tmp tmp\n--sarif\n".getBytes(StandardCharsets.UTF_8));
         final Config config = new Config(file);
-        MatcherAssert.assertThat(config.get("--files"), Matchers.equalTo("sandbox"));
-        MatcherAssert.assertThat(config.get("--tmp"), Matchers.equalTo("tmp"));
-        MatcherAssert.assertThat(config.get("--sarif"), Matchers.equalTo("true"));
-        MatcherAssert.assertThat(config.get("null"), Matchers.nullValue());
+        Assertions.assertEquals(new ListOf<>(config), new ListOf<>("--files", "sandbox", "--tmp", "tmp", "--sarif"));
     }
 
     @Test
@@ -60,8 +58,7 @@ final class ConfigTest {
         final Path file = tmp.resolve(ConfigTest.CONFIG_FILENAME);
         Files.write(file, "\n\n\n\n--includeRules a b c d".getBytes(StandardCharsets.UTF_8));
         final Config config = new Config(file);
-        MatcherAssert.assertThat(new ListOf<>(config), Matchers.hasSize(1));
-        MatcherAssert.assertThat(config.get("--includeRules"), Matchers.equalTo("a b c d"));
+        Assertions.assertEquals(new ListOf<>(config), new ListOf<>("--includeRules", "a", "b", "c", "d"));
     }
 
     @Test

--- a/src/test/java/org/polystat/ConfigTest.java
+++ b/src/test/java/org/polystat/ConfigTest.java
@@ -1,0 +1,74 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020-2022 Polystat.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.polystat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.cactoos.list.ListOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Test cases for {@code Config} object.
+ * @since 1.0
+ */
+final class ConfigTest {
+
+    /**
+     * Name of the configuration file.
+     */
+    private static final String CONFIG_FILENAME = ".polystat";
+
+    @Test
+    void readsOptionsCorrectly(@TempDir final Path tmp) throws IOException {
+        final Path file = tmp.resolve(ConfigTest.CONFIG_FILENAME);
+        Files.write(file, "--files sandbox\n--tmp tmp\n--sarif\n".getBytes(StandardCharsets.UTF_8));
+        final Config config = new Config(file);
+        MatcherAssert.assertThat(config.get("--files"), Matchers.equalTo("sandbox"));
+        MatcherAssert.assertThat(config.get("--tmp"), Matchers.equalTo("tmp"));
+        MatcherAssert.assertThat(config.get("--sarif"), Matchers.equalTo("true"));
+        MatcherAssert.assertThat(config.get("null"), Matchers.nullValue());
+    }
+
+    @Test
+    void ignoresEmptyLines(@TempDir final Path tmp) throws IOException {
+        final Path file = tmp.resolve(ConfigTest.CONFIG_FILENAME);
+        Files.write(file, "\n\n\n\n--includeRules a b c d".getBytes(StandardCharsets.UTF_8));
+        final Config config = new Config(file);
+        MatcherAssert.assertThat(new ListOf<>(config), Matchers.hasSize(1));
+        MatcherAssert.assertThat(config.get("--includeRules"), Matchers.equalTo("a b c d"));
+    }
+
+    @Test
+    void fileDoesNotExist(@TempDir final Path tmp) throws IOException {
+        final Path file = tmp.resolve("foo");
+        final Config config = new Config(file);
+        MatcherAssert.assertThat(new ListOf<>(config), Matchers.empty());
+    }
+
+}

--- a/src/test/java/org/polystat/ConfigTest.java
+++ b/src/test/java/org/polystat/ConfigTest.java
@@ -50,7 +50,10 @@ final class ConfigTest {
         final Path file = tmp.resolve(ConfigTest.CONFIG_FILENAME);
         Files.write(file, "--files sandbox\n--tmp tmp\n--sarif\n".getBytes(StandardCharsets.UTF_8));
         final Config config = new Config(file);
-        Assertions.assertEquals(new ListOf<>(config), new ListOf<>("--files", "sandbox", "--tmp", "tmp", "--sarif"));
+        Assertions.assertEquals(
+            new ListOf<>("--files", "sandbox", "--tmp", "tmp", "--sarif"),
+            new ListOf<>(config)
+        );
     }
 
     @Test
@@ -58,7 +61,10 @@ final class ConfigTest {
         final Path file = tmp.resolve(ConfigTest.CONFIG_FILENAME);
         Files.write(file, "\n\n\n\n--includeRules a b c d".getBytes(StandardCharsets.UTF_8));
         final Config config = new Config(file);
-        Assertions.assertEquals(new ListOf<>(config), new ListOf<>("--includeRules", "a", "b", "c", "d"));
+        Assertions.assertEquals(
+            new ListOf<>("--includeRules", "a", "b", "c", "d"),
+            new ListOf<>(config)
+        );
     }
 
     @Test


### PR DESCRIPTION
Closes #56.

## Configuration
This pull request allows `polystat.jar` to read the command-line options from a file in the current working directory named `.polystat`. This file essentially contains a list of newline-separated command-line options. 
- If this file doesn't exist, the command-line options are used instead.
- If this file exists, the options specified in the `.polystat` file ARE OVERRIDDEN by the options supplied directly on the command line .

## New options
`--include <string>...` - specifies a list of rule IDs that WILL be present in the output.
`--exclude <string>...` - specifies a list of rules IDs that WILL NOT be present in the output.

For example, `--include DIV0` will produce the output where only the results from the FaR analyzer are present.
Conversely, `--exclude DIV0` will produce the output where the results of all analyzers EXCEPT those of FaR are present.

Both options are repeatable, which means that `polystat --include DIV0 --include "Mutual Recursion"` is a valid invocation. They are also mutually exclusive, which means only one of them can be specified.

@yegor256 what do you think?