### PR TITLE
(#8) - Remove a result XML file if a source file no longer exist

### DIFF
--- a/src/main/java/org/polystat/Program.java
+++ b/src/main/java/org/polystat/Program.java
@@ -68,8 +68,13 @@ public final class Program implements Func<String, XML> {
     public XML apply(final String locator) throws Exception {
         final String[] parts = locator.split("\\.");
         final String name = parts[1];
-        final Path xml = this.temp.resolve(String.format("%s.xml", name));
-        final Path src = this.sources.resolve(String.format("%s.eo", name));
+        final Path xml = this.temp.resolve(String.format("%s.xml", name)).toAbsolutePath();
+        final Path src = this.sources.resolve(String.format("%s.eo", name)).toAbsolutePath();
+        if (!src.toFile().exists()) {
+            if (xml.toFile().exists()) {
+                xml.toFile().delete();
+            }
+        }
         if (
             !xml.toFile().exists()
                 || xml.toFile().lastModified() < src.toFile().lastModified()

--- a/src/main/java/org/polystat/Program.java
+++ b/src/main/java/org/polystat/Program.java
@@ -70,10 +70,8 @@ public final class Program implements Func<String, XML> {
         final String name = parts[1];
         final Path xml = this.temp.resolve(String.format("%s.xml", name)).toAbsolutePath();
         final Path src = this.sources.resolve(String.format("%s.eo", name)).toAbsolutePath();
-        if (!src.toFile().exists()) {
-            if (xml.toFile().exists()) {
-                xml.toFile().delete();
-            }
+        if (!src.toFile().exists() && xml.toFile().exists()) {
+            xml.toFile().delete();
         }
         if (
             !xml.toFile().exists()

--- a/src/main/java/org/polystat/Program.java
+++ b/src/main/java/org/polystat/Program.java
@@ -68,8 +68,8 @@ public final class Program implements Func<String, XML> {
     public XML apply(final String locator) throws Exception {
         final String[] parts = locator.split("\\.");
         final String name = parts[1];
-        final Path xml = this.temp.resolve(String.format("%s.xml", name)).toAbsolutePath();
-        final Path src = this.sources.resolve(String.format("%s.eo", name)).toAbsolutePath();
+        final Path xml = this.temp.resolve(String.format("%s.xml", name));
+        final Path src = this.sources.resolve(String.format("%s.eo", name));
         if (!src.toFile().exists() && xml.toFile().exists()) {
             xml.toFile().delete();
         }

--- a/src/test/java/org/polystat/ProgramTest.java
+++ b/src/test/java/org/polystat/ProgramTest.java
@@ -50,6 +50,11 @@ final class ProgramTest {
      */
     private static final String LOCATOR = "\\Phi.test.fv";
 
+    /**
+     * The test EO file.
+     */
+    private static final String TEST_EO = "test.eo";
+
     @Test
     void interpretOneEolangProgram(@TempDir final Path temp) throws Exception {
         this.writeSources(temp);
@@ -71,7 +76,7 @@ final class ProgramTest {
     void deleteResultIfProgramRemoved(@TempDir final Path temp) throws Exception {
         this.writeSources(temp);
         this.assertOutput(temp, temp);
-        final Path src = temp.resolve("test.eo");
+        final Path src = temp.resolve(ProgramTest.TEST_EO);
         final boolean deleted = src.toFile().delete();
         Assertions.assertTrue(deleted);
         final Program program = new Program(temp, temp);
@@ -83,6 +88,20 @@ final class ProgramTest {
         }
         Assertions.assertTrue(fails);
         Assertions.assertFalse(temp.resolve("test.xml").toFile().exists());
+    }
+
+    @Test
+    void recompileIfProgramChanged(@TempDir final Path temp) throws Exception {
+        this.writeSources(temp);
+        this.assertOutput(temp, temp);
+        final Path src = temp.resolve(ProgramTest.TEST_EO);
+        this.writeFile(
+            new TextOf(
+                new ResourceOf("org/polystat/modified.eo")
+            ),
+            src
+        );
+        this.assertOutput(temp, temp);
     }
 
     /**

--- a/src/test/resources/org/polystat/modified.eo
+++ b/src/test/resources/org/polystat/modified.eo
@@ -1,0 +1,14 @@
++package org.polystat
+
++alias org.polystat.five
+
+[c d] > test
+  add. > @
+    div. c d
+    div.
+      div. d c
+      div.
+        fv
+        c
+
+  five > fv


### PR DESCRIPTION
#8 
**How it was:**
A user runs Polystat with `--files sources --tmp result`, and there is a file `sources/test.eo`. The result of the analysis will be saved to `result/test.xml`. If the user renames or deletes the file `sources/test.eo` and runs the same command again, Polystat will print the previous correct result, taking it from `result/test.xml`, not throwing an exception.

**After changes:**
In the same case Polystat will throw a `FileNotFoundException`.
It throws an exception several times for each running `Analysis`.